### PR TITLE
Catalogremove

### DIFF
--- a/pdfresources.dtx
+++ b/pdfresources.dtx
@@ -455,7 +455,7 @@
 %
 %  \begin{macro}{
 %                \@@_prop_gclear,
-%                \@@_prop_gput:n,
+%                \@@_prop_gput:nnn,
 %                \@@_prop_get:nnN,
 %                \@@_prop_gremove:nn,
 %                \@@_prop_show:n
@@ -2102,6 +2102,7 @@
 %   \end{tabularx}
 %   \par\medskip
 %
+%   \paragraph{Catalog entries with subdictionaries}
 %   The following keys add values to subdictionaries. The syntax is that the
 %   \meta{name}  \meta{value} pair is inputed in a brace pair. E.g.\\
 %   |\pdf_catalog_gput:nn {Acroform}{{SigFlags}{3}}| or\\
@@ -2133,6 +2134,22 @@
 %                            & \ldots          &              \\
 % \end{tabularx}
 %
+%   These rather simple entries can be removed again with the following command:
+%   \begin{function}[added = 2020-03-23]
+%   {\pdf_catalog_gremove:n }
+%   \begin{syntax}
+%     \cs{pdf_catalog_gremove:n}  \Arg{key}
+%   \end{syntax}
+%   This removes an entry from the catalog for the variants above.
+%   described in the following paragraph. In some cases removing such an entry
+%   can be needed if some default value set by a packages interferes with
+%   defaults set by the user in the pdf viewer.
+%   \Arg{key} is either a simple key or a key/subkey combination. Examples
+%   | \pdf_catalog_gremove:n { PageMode } |\\
+%   | \pdf_catalog_gremove:n { ViewerPreferences/HideToolbar } |
+%   \end{function}
+%
+% \paragraph{Catalog entries with multiple values in arrays}
 % The following keys are dictionaries to which multiple values can be
 % assigned which are then combined in an array. The value is -- with the exception
 % of AcroForm/Fields and AcroForm/CO an object name of an object
@@ -2184,6 +2201,20 @@
       }
    }
 \cs_generate_variant:Nn \pdf_catalog_gput:nn {no,nx}
+\cs_new_protected:Npn \pdf_catalog_gremove:n #1 %#1 name
+  {
+    \seq_set_split:Nnn \l_tmpa_seq { / } { #1 }
+    \int_compare:nNnTF { 1 } = {\seq_count:N \l_tmpa_seq }
+     {
+       \@@_prop_gremove:nn { Catalog } { #1 }
+     }
+     {
+       \seq_pop_right:NN \l_tmpa_seq \tl_tmpa_tl
+       \exp_args:Nxx \@@_prop_gremove:nn
+         { Catalog/\seq_use:Nn\l_tmpa_seq { / } }
+         { \tl_tmpa_tl }
+     }
+  }
 %    \end{macrocode}
 % \begin{variable}[added=2019-08-24]
 %     {

--- a/testfiles/catalog-remove.luatex.tlg
+++ b/testfiles/catalog-remove.luatex.tlg
@@ -1,0 +1,50 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+The property list \g__pdf_/Catalog_prop contains the pairs (without outer
+braces):
+>  {Lang}  =>  {(de-De)}
+>  {PageLayout}  =>  {/SinglePage}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog}
+The property list \g__pdf_/Catalog/ViewerPreferences_prop contains the pairs
+(without outer braces):
+>  {HideToolbar}  =>  {true}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/ViewerPreferences}
+The property list \g__pdf_/Catalog/MarkInfo_prop contains the pairs (without
+outer braces):
+>  {Marked}  =>  {True}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/MarkInfo}
+The property list \g__pdf_/Catalog/AcroForm/DR/Font_prop contains the pairs
+(without outer braces):
+>  {Name}  =>  {<</ABC/CDE>>}
+>  {NameB}  =>  {<</ABC/CDE>>}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/AcroForm/DR/Font}
+The property list \g__pdf_/Catalog_prop contains the pairs (without outer
+braces):
+>  {Lang}  =>  {(de-De)}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog}
+The property list \g__pdf_/Catalog/ViewerPreferences_prop is empty
+> .
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/ViewerPreferences}
+The property list \g__pdf_/Catalog/MarkInfo_prop is empty
+> .
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/MarkInfo}
+The property list \g__pdf_/Catalog/AcroForm/DR/Font_prop contains the pairs
+(without outer braces):
+>  {NameB}  =>  {<</ABC/CDE>>}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/AcroForm/DR/Font}
+[1
+]
+Package atveryend Info: Empty hook `BeforeClearDocument' on input line ....
+Package atveryend Info: Executing hook `AfterLastShipout' on input line ....
+(catalog-remove.aux)
+Package atveryend Info: Empty hook `AtVeryEndDocument' on input line ....
+Package atveryend Info: Empty hook `AtEndAfterFileList' on input line ....
+Package atveryend Info: Empty hook `AtVeryVeryEnd' on input line ....

--- a/testfiles/catalog-remove.lvt
+++ b/testfiles/catalog-remove.lvt
@@ -1,0 +1,32 @@
+\input{regression-test}
+\documentclass{article}
+\usepackage{pdfresources}
+\ExplSyntaxOn
+\pdf_uncompress:
+\ExplSyntaxOff
+\begin{document}
+\START
+\ExplSyntaxOn
+\pdf_catalog_gput:nn {Lang}{(de-De)}
+\pdf_catalog_gput:nn {PageLayout}{/SinglePage}
+\pdf_catalog_gput:nn {MarkInfo}{{Marked}{True}}
+\pdf_catalog_gput:nn {ViewerPreferences}{{HideToolbar}{true}}
+\pdf_catalog_gput:nn {AcroForm/DR/Font}{{Name}{<</ABC/CDE>>}}
+\pdf_catalog_gput:nn {AcroForm/DR/Font}{{NameB}{<</ABC/CDE>>}}
+\__pdf_prop_show:n {Catalog}
+\__pdf_prop_show:n {Catalog/ViewerPreferences}
+\__pdf_prop_show:n {Catalog/MarkInfo}
+\__pdf_prop_show:n {Catalog/AcroForm/DR/Font}
+\pdf_catalog_gremove:n{ViewerPreferences/HideToolbar}
+\pdf_catalog_gremove:n{PageMode}
+\pdf_catalog_gremove:n{PageLayout}
+\pdf_catalog_gremove:n{MarkInfo/Marked}
+\pdf_catalog_gremove:n{AcroForm/DR/Font/Name}
+\__pdf_prop_show:n {Catalog}
+\__pdf_prop_show:n {Catalog/ViewerPreferences}
+\__pdf_prop_show:n {Catalog/MarkInfo}
+\__pdf_prop_show:n {Catalog/AcroForm/DR/Font}
+
+\ExplSyntaxOff
+blub
+\end{document}

--- a/testfiles/catalog-remove.tlg
+++ b/testfiles/catalog-remove.tlg
@@ -1,0 +1,50 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+The property list \g__pdf_/Catalog_prop contains the pairs (without outer
+braces):
+>  {Lang}  =>  {(de-De)}
+>  {PageLayout}  =>  {/SinglePage}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog}
+The property list \g__pdf_/Catalog/ViewerPreferences_prop contains the pairs
+(without outer braces):
+>  {HideToolbar}  =>  {true}.
+<recently read> }
+l. ......df_prop_show:n {Catalog/ViewerPreferences}
+The property list \g__pdf_/Catalog/MarkInfo_prop contains the pairs (without
+outer braces):
+>  {Marked}  =>  {True}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/MarkInfo}
+The property list \g__pdf_/Catalog/AcroForm/DR/Font_prop contains the pairs
+(without outer braces):
+>  {Name}  =>  {<</ABC/CDE>>}
+>  {NameB}  =>  {<</ABC/CDE>>}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/AcroForm/DR/Font}
+The property list \g__pdf_/Catalog_prop contains the pairs (without outer
+braces):
+>  {Lang}  =>  {(de-De)}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog}
+The property list \g__pdf_/Catalog/ViewerPreferences_prop is empty
+> .
+<recently read> }
+l. ......df_prop_show:n {Catalog/ViewerPreferences}
+The property list \g__pdf_/Catalog/MarkInfo_prop is empty
+> .
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/MarkInfo}
+The property list \g__pdf_/Catalog/AcroForm/DR/Font_prop contains the pairs
+(without outer braces):
+>  {NameB}  =>  {<</ABC/CDE>>}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/AcroForm/DR/Font}
+[1
+]
+Package atveryend Info: Empty hook `BeforeClearDocument' on input line ....
+Package atveryend Info: Executing hook `AfterLastShipout' on input line ....
+(catalog-remove.aux)
+Package atveryend Info: Empty hook `AtVeryEndDocument' on input line ....
+Package atveryend Info: Empty hook `AtEndAfterFileList' on input line ....
+Package atveryend Info: Empty hook `AtVeryVeryEnd' on input line ....

--- a/testfiles/catalog-remove.xetex.tlg
+++ b/testfiles/catalog-remove.xetex.tlg
@@ -1,0 +1,50 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+The property list \g__pdf_/Catalog_prop contains the pairs (without outer
+braces):
+>  {Lang}  =>  {(de-De)}
+>  {PageLayout}  =>  {/SinglePage}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog}
+The property list \g__pdf_/Catalog/ViewerPreferences_prop contains the pairs
+(without outer braces):
+>  {HideToolbar}  =>  {true}.
+<recently read> }
+l. ......df_prop_show:n {Catalog/ViewerPreferences}
+The property list \g__pdf_/Catalog/MarkInfo_prop contains the pairs (without
+outer braces):
+>  {Marked}  =>  {True}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/MarkInfo}
+The property list \g__pdf_/Catalog/AcroForm/DR/Font_prop contains the pairs
+(without outer braces):
+>  {Name}  =>  {<</ABC/CDE>>}
+>  {NameB}  =>  {<</ABC/CDE>>}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/AcroForm/DR/Font}
+The property list \g__pdf_/Catalog_prop contains the pairs (without outer
+braces):
+>  {Lang}  =>  {(de-De)}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog}
+The property list \g__pdf_/Catalog/ViewerPreferences_prop is empty
+> .
+<recently read> }
+l. ......df_prop_show:n {Catalog/ViewerPreferences}
+The property list \g__pdf_/Catalog/MarkInfo_prop is empty
+> .
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/MarkInfo}
+The property list \g__pdf_/Catalog/AcroForm/DR/Font_prop contains the pairs
+(without outer braces):
+>  {NameB}  =>  {<</ABC/CDE>>}.
+<recently read> }
+l. ...\__pdf_prop_show:n {Catalog/AcroForm/DR/Font}
+Package atveryend Info: Empty hook `BeforeClearDocument' on input line ....
+[1
+]
+Package atveryend Info: Executing hook `AfterLastShipout' on input line ....
+(catalog-remove.aux)
+Package atveryend Info: Empty hook `AtVeryEndDocument' on input line ....
+Package atveryend Info: Empty hook `AtEndAfterFileList' on input line ....
+Package atveryend Info: Empty hook `AtVeryVeryEnd' on input line ....


### PR DESCRIPTION
This implements a partial \pdf_catalog_gremove:n function which is imho needed  for the generic hyperref driver for a number of values.

The syntax to remove something from a subdictionary is e.g.

~~~~
\pdf_catalog_gremove:nn { ViewerPreferences/HideToolbar }
~~~~

Imho I should change the syntax to add to such subdictionaries from

~~~~
\pdf_catalog_gput:nn { ViewerPreferences } {{ HideToolbar } { true }} 
~~~~

to

~~~~
\pdf_catalog_gput:nn { ViewerPreferences/HideToolbar } { true } 
~~~~

this looks more consistent.  