### PR TITLE
Fix "smart quotes"

### DIFF
--- a/hyperref-generic.dtx
+++ b/hyperref-generic.dtx
@@ -1102,7 +1102,7 @@
   { hyp }
   { unknown-key }
   {
-    unknown~key~#2~of~module~’#1’~set~to~’#3’.
+    unknown~key~#2~of~module~'#1'~set~to~'#3'.
   }
 \msg_new:nnn
   { hyp }


### PR DESCRIPTION
The "smart"-quotes cause errors when the log is being parsed, for example by `latexmk`