### PR TITLE
fix \cs in verbatim

### DIFF
--- a/hyperref-generic.dtx
+++ b/hyperref-generic.dtx
@@ -211,7 +211,7 @@
 %
 %  \item |pdflang| is deprecated. Instead \cs{DocumentMetadata} should be used:
 %  \begin{verbatim}
-%  \cs{DocumentMetadata}{lang=de-DE}
+%  \DocumentMetadata{lang=de-DE}
 %  \end{verbatim}
 %
 %  The value can be retrieved as |document/lang|.


### PR DESCRIPTION
Removes a use of `\cs` in a `verbatim` environment in hyperref-generic.