### PR TITLE
Add \LogDocumentProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+ - ltdocinit.dtx: add \LogDocumentProperties
+
 ### Fixed 
  - colorspace-patches-tmp-ltx.sty: fixes hook use, issue #78
  

--- a/ltdocinit.dtx
+++ b/ltdocinit.dtx
@@ -197,11 +197,12 @@
 %   stream.  The \meta{token list variable} is assigned locally.
 % \end{function}
 % 
-% \begin{function}{\ShowDocumentProperties}
+% \begin{function}{\ShowDocumentProperties,\LogDocumentProperties}
 % \begin{syntax}
-%  \cs{ShowDocumentProperties}
+%  \cs{ShowDocumentProperties}\\
+%  \cs{LogDocumentProperties}
 % \end{syntax}
-% This show the current content of the container.
+% This shows/logs the current content of the container.
 % \end{function}
 %
 % \begin{thebibliography}{9}
@@ -320,6 +321,13 @@
 \NewDocumentCommand\ShowDocumentProperties {}
   {
     \msg_show:nne {pdfmanagement}{show-properties}
+      {
+        \prop_map_function:NN \g_@@_documentproperties_prop \msg_show_item:nn
+      }
+  }
+\NewDocumentCommand\LogDocumentProperties {}
+  {
+    \msg_log:nne {pdfmanagement}{show-properties}
       {
         \prop_map_function:NN \g_@@_documentproperties_prop \msg_show_item:nn
       }


### PR DESCRIPTION
Personally, I prefer debug logging to go into the log file. The code is just a one word change from \ShowDocumentProperties.

I could not figure out how to add a test, because lots of LuaTeX tests kept failing for reasons unknown to me.